### PR TITLE
Added div icon, controls, layer options, leaflet 1.6.0 support and some dart2js minor fixes

### DIFF
--- a/example/draw_flowers.dart
+++ b/example/draw_flowers.dart
@@ -16,8 +16,7 @@ class DrawFlowers implements Draw {
   }
 
   @override
-  String get geoJson => "Not implemented";
-
+  String get geoJson => 'Not implemented';
 
   void _putLeaf(LeafletMouseEvent e) {
     var options = IconOptions(
@@ -28,13 +27,13 @@ class DrawFlowers implements Draw {
         // point of the icon which will correspond to marker's location
         iconAnchor: Point(22, 94),
         shadowAnchor: Point(4, 62), // the same for the shadow
-// point from which the popup should open relative to the iconAnchor
+        // point from which the popup should open relative to the iconAnchor
         popupAnchor: Point(-3, -76));
 
     var pop = Popup()..setContent('<p>Hello</p>');
     Marker(e.latlng, MarkerOptions(icon: Icon(options)))
       ..bindPopup(pop)
-      ..bindTooltip("Click to learn more")
+      ..bindTooltip('Click to learn more')
       ..addTo(_map);
   }
 }

--- a/example/draw_polygons.dart
+++ b/example/draw_polygons.dart
@@ -9,8 +9,8 @@ class DrawPolygons implements Draw {
   CircleMarker _firstMark;
 
   final _featureCollection = <String, dynamic>{
-    "type": "FeatureCollection",
-    "features": <Map>[]
+    'type': 'FeatureCollection',
+    'features': <Map>[]
   };
 
   Polyline _polyline = Polyline([]);
@@ -28,16 +28,16 @@ class DrawPolygons implements Draw {
 
   final _normalNode = CircleOptions()
     ..radius = 5
-    ..fillColor = "#ff7800"
-    ..color = "#000"
+    ..fillColor = '#ff7800'
+    ..color = '#000'
     ..weight = 1
     ..opacity = 1
     ..fillOpacity = 0.8;
 
   final _accentNode = CircleOptions()
     ..radius = 10
-    ..fillColor = "#aa7880"
-    ..color = "#000"
+    ..fillColor = '#aa7880'
+    ..color = '#000'
     ..weight = 2
     ..opacity = 1
     ..fillOpacity = 0.9;
@@ -54,7 +54,7 @@ class DrawPolygons implements Draw {
 
       _polyline.addTo(_map);
       _dashLine.addTo(_map);
-      _dashLine.setStyle(PolylineOptions()..dashArray = "4");
+      _dashLine.setStyle(PolylineOptions()..dashArray = '4');
     } else {
       _map.dragging.enable();
       _map.off(E.mousedown);
@@ -150,6 +150,6 @@ class DrawPolygons implements Draw {
         'coordinates': geojson.geometry.coordinates
       }
     };
-    _featureCollection["features"].add(json);
+    _featureCollection['features'].add(json);
   }
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -3,7 +3,7 @@ import 'dart:html';
 import 'open_street_map.dart';
 
 void main() {
-  var map = OpenStreetMap("output");
+  var map = OpenStreetMap('output');
   map.setView(lat: 43.21047, lng: 27.93470, zoom: 15);
 
   querySelectorAll('input[name=drawOption]').onClick.listen((MouseEvent e) {
@@ -11,8 +11,8 @@ void main() {
     map.draw(btn.id, btn.checked);
   });
 
-  querySelector("#btnGetGeoJson").onClick.listen((_) {
-      var json = map.geoJson;
-      print(json);
+  querySelector('#btnGetGeoJson').onClick.listen((_) {
+    var json = map.geoJson;
+    print(json);
   });
 }

--- a/example/open_street_map.dart
+++ b/example/open_street_map.dart
@@ -18,16 +18,16 @@ class OpenStreetMap {
     TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', options)
         .addTo(_map);
 
-    // disable the default right click - use it as cancel last poitn
-    var map = querySelector("#$elementId");
+    // disable the default right click - use it as cancel last point
+    var map = querySelector('#$elementId');
     map.addEventListener('contextmenu', (Event e) {
       e.preventDefault();
       return false;
     });
 
-    _painters["marker"] = DrawFlowers(_map);
-    _painters["circle"] = DrawCircles(_map);
-    _painters["polygon"] = DrawPolygons(_map);
+    _painters['marker'] = DrawFlowers(_map);
+    _painters['circle'] = DrawCircles(_map);
+    _painters['polygon'] = DrawPolygons(_map);
   }
 
   void draw(String item, bool enabled) {
@@ -37,7 +37,7 @@ class OpenStreetMap {
     }
   }
 
-  String get geoJson => _painters["polygon"].geoJson;
+  String get geoJson => _painters['polygon'].geoJson;
 
   void setView({double lat, double lng, double zoom = 10}) =>
       _map.setView(LatLng(lat, lng), zoom);

--- a/lib/dartleaf.dart
+++ b/lib/dartleaf.dart
@@ -5,6 +5,7 @@ export 'src/latlng_bounds.dart';
 export 'src/latlng.dart';
 export 'src/renderer.dart';
 export 'src/crs.dart';
+export 'src/control.dart';
 export 'src/marker.dart';
 export 'src/path.dart';
 export 'src/popup.dart';

--- a/lib/src/bounds.dart
+++ b/lib/src/bounds.dart
@@ -4,7 +4,7 @@ library leaflet.bounds;
 import 'package:js/js.dart';
 import 'point.dart';
 
-@JS("L.bounds")
+@JS('L.bounds')
 class Bounds {
   /// Creates a Bounds object from two corners coordinate pairs.
   external Bounds(Point corner1, Point corner2);
@@ -51,34 +51,13 @@ class Bounds {
 @JS()
 @anonymous
 class FitBoundOptions {
-  external factory FitBoundOptions(
-      {Point paddingTopLeft,
-      Point paddingBottomRight,
-      Point padding,
-      double maxZoom});
+  external factory FitBoundOptions({
+    Point paddingTopLeft,
+    Point paddingBottomRight,
+    Point padding,
+    double maxZoom,
+  });
 
-  /// Sets the amount of padding in the top left corner of a map container that shouldn't be accounted for
-  /// when setting the view to fit bounds. Useful if you have some control overlays on the map like a sidebar
-  /// and you don't want them to obscure objects you're zooming to.
-  external Point get paddingTopLeft;
-  external set paddingTopLeft(Point value);
-
-  /// The same for the bottom right corner of the map.
-  external Point get paddingBottomRight;
-  external set paddingBottomRight(Point value);
-
-  /// Equivalent of setting both top left and bottom right padding to the same value.
-  external Point get padding;
-  external set padding(Point value);
-
-  /// The maximum possible zoom to use
-  external double get maxZoom;
-  external set maxZoom(double value);
-}
-
-@JS()
-@anonymous
-class FitBounds {
   /// Sets the amount of padding in the top left corner of a map container that shouldn't be accounted for
   /// when setting the view to fit bounds. Useful if you have some control overlays on the map like a sidebar
   /// and you don't want them to obscure objects you're zooming to.

--- a/lib/src/control.dart
+++ b/lib/src/control.dart
@@ -3,10 +3,13 @@ library leaflet.control;
 
 import 'dart:html';
 import 'package:js/js.dart';
+import '../dartleaf.dart';
 import 'leaflet_map.dart';
 
-@JS("L.control")
+@JS('L.control')
 class Control {
+  external Control([ControlOptions options]);
+
   /// Returns the position of the control.
   external String getPosition();
 
@@ -32,3 +35,173 @@ class ControlOptions {
   external String get position;
   external set position(String value);
 }
+
+/// A basic zoom control with two buttons (zoom in and zoom out).
+/// It is put on the map by default unless you set its [zoomControl] option to false.
+@JS('L.control.zoom')
+class ZoomControl extends Control {
+  external ZoomControl([ZoomControlOptions options]);
+}
+
+@JS()
+@anonymous
+class ZoomControlOptions extends ControlOptions {
+  external factory ZoomControlOptions({
+    String position,
+    String zoomInText,
+    String zoomInTitle,
+    String zoomOutText,
+    String zoomOutTitle,
+  });
+
+  /// The text set on the 'zoom in' button ('+' by default).
+  external String get zoomInText;
+  external set zoomInText(String value);
+
+  /// The title set on the 'zoom in' button ('Zoom in' by default).
+  external String get zoomInTitle;
+  external set zoomInTitle(String value);
+
+  /// The text set on the 'zoom out' button ('&#x2212  ' by default).
+  external String get zoomOutText;
+  external set zoomOutText(String value);
+
+  /// The title set on the 'zoom out' button ('Zoom out' by default).
+  external String get zoomOutTitle;
+  external set zoomOutTitle(String value);
+}
+
+/// The attribution control allows you to display attribution data in a small text box on a map.
+/// It is put on the map by default unless you set its attributionControl option to false,
+/// and it fetches attribution texts from layers with the getAttribution method automatically.
+@JS('L.control.attribution')
+class AttributionControl extends Control {
+  external AttributionControl([AttributionControlOptions options]);
+}
+
+@JS()
+@anonymous
+class AttributionControlOptions extends ControlOptions {
+  external factory AttributionControlOptions({
+    String position,
+    String prefix,
+  });
+
+  /// The HTML text shown before the attributions ('Leaflet' by default).
+  /// Pass `null` to disable.
+  external String get prefix;
+  external set prefix(String value);
+}
+
+/// A simple scale control that shows the scale of the current center
+/// of screen in metric (m/km) and imperial (mi/ft) systems.
+@JS('L.control.scale')
+class ScaleControl extends Control {
+  external ScaleControl([ScaleControlOptions options]);
+}
+
+@JS()
+@anonymous
+class ScaleControlOptions extends ControlOptions {
+  external factory ScaleControlOptions({
+    String position,
+    String prefix,
+  });
+
+  /// Number  100 Maximum width of the control in pixels.
+  /// The width is set dynamically to show round values (e.g. 100, 200, 500).
+  external num get maxWidth;
+  external set maxWidth(num value);
+
+  /// Whether to show the metric scale line (m/km). Default to `true`.
+  external bool get metric;
+  external set metric(bool value);
+
+  /// Whether to show the imperial scale line (mi/ft). Default to `true`.
+  external bool get imperial;
+  external set imperial(bool value);
+
+  /// If `true`, the control is updated on `moveend`, otherwise it's always
+  /// up-to-date (updated on move). Default to `false`.
+  external bool get updateWhenIdle;
+  external set updateWhenIdle(bool value);
+}
+
+/// The layers control gives users the ability to switch between different base
+/// layers and switch overlays on/off.
+@JS('L.control.layers')
+class LayersControl extends Control {
+  /// Creates a layers control with the given layers.
+  ///
+  /// The [baseLayers] and [overlays] parameters are object literals with layer names as keys and [Layer] objects as values.
+  /// Note: Since dart2js interop doesn't transpile dart maps to native js map directly,
+  /// you will have to create anonymous anotated classes for each different [baselayers] and [overlays] object
+  /// (or just use the [addBaseLayer] and [addOverlay] instance methods).
+  ///
+  /// Base layers will be switched with radio buttons, while overlays will be switched with checkboxes.
+  /// Note that all base layers should be passed in the base layers object,
+  /// but only one should be added to the map during map instantiation.
+  external LayersControl([
+    dynamic baselayers,
+    dynamic overlays,
+    LayersControlOptions options,
+  ]);
+
+  /// Adds a base layer (radio button entry) with the given name to the control.
+  external LayersControl addBaseLayer(Layer layer, String name);
+
+  /// Adds an overlay (checkbox entry) with the given name to the control.
+  external LayersControl addOverlay(Layer layer, String name);
+
+  /// Remove the given layer from the control.
+  external LayersControl removeLayer(Layer layer);
+
+  /// Expand the control container if collapsed.
+  external LayersControl expand();
+
+  /// Collapse the control container if expanded.
+  external LayersControl collapse();
+}
+
+@JS()
+@anonymous
+class LayersControlOptions extends ControlOptions {
+  external factory LayersControlOptions({
+    String position,
+    bool collapsed,
+    bool autoZIndex,
+    bool hideSingleBase,
+    bool sortLayers,
+    LayersSortFunction sortFunction,
+  });
+
+  /// If `true`, the control will be collapsed into an icon and expanded on mouse hover or touch (`true` by default).
+  external bool get collapsed;
+  external set collapsed(bool value);
+
+  /// If `true`, the control will assign zIndexes in increasing order to all of its
+  /// layers so that the order is preserved when switching them on/off (`true` by default).
+  external bool get autoZIndex;
+  external set autoZIndex(bool value);
+
+  /// If `true`, the base layers in the control will be hidden when there is only one (`false` by default).
+  external bool get hideSingleBase;
+  external set hideSingleBase(bool value);
+
+  /// Whether to sort the layers. When `false`, layers will keep the order in which
+  /// they were added to the control (`false` by default).
+  external bool get sortLayers;
+  external set sortLayers(bool value);
+
+  /// A compare function that will be used for sorting the layers, when [sortLayers] is true.
+  /// By default, it sorts layers alphabetically by their name.
+  external LayersSortFunction get sortFunction;
+  external set sortFunction(LayersSortFunction value);
+}
+
+typedef LayersSortFunction = Function(
+  Layer layerA,
+  Layer layerB,
+  String nameA,
+  String nameB,
+);

--- a/lib/src/crs.dart
+++ b/lib/src/crs.dart
@@ -8,7 +8,7 @@ import 'point.dart';
 import 'bounds.dart';
 import 'latlng_bounds.dart';
 
-@JS("CRS")
+@JS('CRS')
 class CRS extends Layer {
   /// Projects geographical coordinates into pixel coordinates for a given zoom.
   external Point latLngToPoint(LatLng latlng, double zoom);

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -12,119 +12,119 @@ import 'popup.dart';
 import 'latlng_bounds.dart';
 
 class E {
-  /// 	LayersControlEvent 	Fired when the base layer is changed through the layer control.
-  static const baselayerchange = "baselayerchange";
+  /// LayersControlEvent  Fired when the base layer is changed through the layer control.
+  static const baselayerchange = 'baselayerchange';
 
-  /// 	LayersControlEvent 	Fired when an overlay is selected through the layer control.
-  static const overlayadd = "overlayadd";
+  /// LayersControlEvent  Fired when an overlay is selected through the layer control.
+  static const overlayadd = 'overlayadd';
 
-  /// 	LayersControlEvent 	Fired when an overlay is deselected through the layer control.
-  static const overlayremove = "overlayremove";
+  /// LayersControlEvent  Fired when an overlay is deselected through the layer control.
+  static const overlayremove = 'overlayremove';
 
-  /// 	LayerEvent 	Fired when a new layer is added to the map.
-  static const layeradd = "layeradd";
+  /// LayerEvent  Fired when a new layer is added to the map.
+  static const layeradd = 'layeradd';
 
-  /// 	LayerEvent 	Fired when some layer is removed from the map
-  static const layerremove = "layerremove";
+  /// LayerEvent  Fired when some layer is removed from the map
+  static const layerremove = 'layerremove';
 
   /// Map state change events
-  /// 	Event 	Fired when the number of zoomlevels on the map is changed due to adding or removing a layer.
-  static const zoomlevelschange = "zoomlevelschange";
+  /// Event   Fired when the number of zoomlevels on the map is changed due to adding or removing a layer.
+  static const zoomlevelschange = 'zoomlevelschange';
 
-  /// 	ResizeEvent 	Fired when the map is resized.
-  static const resize = "resize";
+  /// ResizeEvent   Fired when the map is resized.
+  static const resize = 'resize';
 
-  /// 	Event 	Fired when the map is destroyed with remove method.
-  static const unload = "unload";
+  /// Event   Fired when the map is destroyed with remove method.
+  static const unload = 'unload';
 
-  /// 	Event 	Fired when the map needs to redraw its content (this usually happens on map zoom or load). Very useful for creating custom overlays.
-  static const viewreset = "viewreset";
+  /// Event   Fired when the map needs to redraw its content (this usually happens on map zoom or load). Very useful for creating custom overlays.
+  static const viewreset = 'viewreset';
 
-  /// 	Event 	Fired when the map is initialized (when its center and zoom are set for the first time).
-  static const load = "load";
+  /// Event   Fired when the map is initialized (when its center and zoom are set for the first time).
+  static const load = 'load';
 
-  /// 	Event 	Fired when the map zoom is about to change (e.g. before zoom animation).
-  static const zoomstart = "zoomstart";
+  /// Event   Fired when the map zoom is about to change (e.g. before zoom animation).
+  static const zoomstart = 'zoomstart';
 
-  /// 	Event 	Fired when the view of the map starts changing (e.g. user starts dragging the map).
-  static const movestart = "movestart";
+  /// Event   Fired when the view of the map starts changing (e.g. user starts dragging the map).
+  static const movestart = 'movestart';
 
-  /// 	Event 	Fired repeatedly during any change in zoom level, including zoom and fly animations.
-  static const zoom = "zoom";
+  /// Event   Fired repeatedly during any change in zoom level, including zoom and fly animations.
+  static const zoom = 'zoom';
 
-  /// 	Event 	Fired repeatedly during any movement of the map, including pan and fly animations.
-  static const move = "move";
+  /// Event   Fired repeatedly during any movement of the map, including pan and fly animations.
+  static const move = 'move';
 
-  /// 	Event 	Fired when the map has changed, after any animations.
-  static const zoomend = "zoomend";
+  /// Event   Fired when the map has changed, after any animations.
+  static const zoomend = 'zoomend';
 
-  /// 	Event 	Fired when the center of the map stops changing (e.g. user stopped dragging the map).
-  static const moveend = "moveend";
+  /// Event   Fired when the center of the map stops changing (e.g. user stopped dragging the map).
+  static const moveend = 'moveend';
 
   /// Popup events
-  /// 	PopupEvent 	Fired when a popup is opened in the map
-  static const popupopen = "popupopen";
+  /// PopupEvent  Fired when a popup is opened in the map
+  static const popupopen = 'popupopen';
 
-  /// 	PopupEvent 	Fired when a popup in the map is closed
-  static const popupclose = "popupclose";
+  /// PopupEvent  Fired when a popup in the map is closed
+  static const popupclose = 'popupclose';
 
-  /// 	Event 	Fired when the map starts autopanning when opening a popup.
-  static const autopanstart = "autopanstart";
+  /// Event   Fired when the map starts autopanning when opening a popup.
+  static const autopanstart = 'autopanstart';
 
   /// Tooltip events
-  /// 	TooltipEvent 	Fired when a tooltip is opened in the map.
-  static const tooltipopen = "tooltipopen";
+  /// TooltipEvent  Fired when a tooltip is opened in the map.
+  static const tooltipopen = 'tooltipopen';
 
-  /// 	TooltipEvent 	Fired when a tooltip in the map is closed.
-  static const tooltipclose = "tooltipclose";
+  /// TooltipEvent  Fired when a tooltip in the map is closed.
+  static const tooltipclose = 'tooltipclose';
 
   /// Location events
-  /// 	ErrorEvent 	Fired when geolocation (using the locate method) failed.
-  static const locationerror = "locationerror";
+  /// ErrorEvent  Fired when geolocation (using the locate method) failed.
+  static const locationerror = 'locationerror';
 
-  /// 	LocationEvent 	Fired when geolocation (using the locate method) went successfully.
-  static const locationfound = "locationfound";
+  /// LocationEvent   Fired when geolocation (using the locate method) went successfully.
+  static const locationfound = 'locationfound';
 
   /// Interaction events
-  /// 	MouseEvent 	Fired when the user clicks (or taps) the map.
-  static const click = "click";
+  /// MouseEvent  Fired when the user clicks (or taps) the map.
+  static const click = 'click';
 
-  /// 	MouseEvent 	Fired when the user double-clicks (or double-taps) the map.
-  static const dblclick = "dblclick";
+  /// MouseEvent  Fired when the user double-clicks (or double-taps) the map.
+  static const dblclick = 'dblclick';
 
-  /// 	MouseEvent 	Fired when the user pushes the mouse button on the map.
-  static const mousedown = "mousedown";
+  /// MouseEvent  Fired when the user pushes the mouse button on the map.
+  static const mousedown = 'mousedown';
 
-  /// 	MouseEvent 	Fired when the user releases the mouse button on the map.
-  static const mouseup = "mouseup";
+  /// MouseEvent  Fired when the user releases the mouse button on the map.
+  static const mouseup = 'mouseup';
 
-  /// 	MouseEvent 	Fired when the mouse enters the map.
-  static const mouseover = "mouseover";
+  /// MouseEvent  Fired when the mouse enters the map.
+  static const mouseover = 'mouseover';
 
-  /// 	MouseEvent 	Fired when the mouse leaves the map.
-  static const mouseout = "mouseout";
+  /// MouseEvent  Fired when the mouse leaves the map.
+  static const mouseout = 'mouseout';
 
-  /// 	MouseEvent 	Fired while the mouse moves over the map.
-  static const mousemove = "mousemove";
+  /// MouseEvent  Fired while the mouse moves over the map.
+  static const mousemove = 'mousemove';
 
-  /// 	MouseEvent 	Fired when the user pushes the right mouse button on the map, prevents default browser context menu from showing if there are listeners on this event. Also fired on mobile when the user holds a single touch for a second (also called long press).
-  static const contextmenu = "contextmenu";
+  /// MouseEvent  Fired when the user pushes the right mouse button on the map, prevents default browser context menu from showing if there are listeners on this event. Also fired on mobile when the user holds a single touch for a second (also called long press).
+  static const contextmenu = 'contextmenu';
 
-  /// 	KeyboardEvent 	Fired when the user presses a key from the keyboard that produces a character value while the map is focused.
-  static const keypress = "keypress";
+  /// KeyboardEvent   Fired when the user presses a key from the keyboard that produces a character value while the map is focused.
+  static const keypress = 'keypress';
 
-  /// 	KeyboardEvent 	Fired when the user presses a key from the keyboard while the map is focused. Unlike the keypress event, the keydown event is fired for keys that produce a character value and for keys that do not produce a character value.
-  static const keydown = "keydown";
+  /// KeyboardEvent   Fired when the user presses a key from the keyboard while the map is focused. Unlike the keypress event, the keydown event is fired for keys that produce a character value and for keys that do not produce a character value.
+  static const keydown = 'keydown';
 
-  /// 	KeyboardEvent 	Fired when the user releases a key from the keyboard while the map is focused.
-  static const keyup = "keyup";
+  /// KeyboardEvent   Fired when the user releases a key from the keyboard while the map is focused.
+  static const keyup = 'keyup';
 
-  /// 	MouseEvent 	Fired before mouse click on the map (sometimes useful when you want something to happen on click before any existing click handlers start running).
-  static const preclick = "preclick";
+  /// MouseEvent  Fired before mouse click on the map (sometimes useful when you want something to happen on click before any existing click handlers start running).
+  static const preclick = 'preclick';
 
   ///Other Methods
-  /// 	ZoomAnimEvent 	Fired at least once per zoom animation. For continuous zoom, like pinch zooming, fired once per frame during zoom.
-  static const zoomanim = "zoomanim";
+  /// ZoomAnimEvent   Fired at least once per zoom animation. For continuous zoom, like pinch zooming, fired once per frame during zoom.
+  static const zoomanim = 'zoomanim';
 }
 
 /// Event
@@ -132,13 +132,13 @@ class E {
 @JS()
 @anonymous
 class LeafletEvent {
-  ///  The event type (e.g. 'click').
+  /// The event type (e.g. 'click').
   external String get type;
 
   /// The object that fired the event. For propagated events, the last object in the propagation chain that fired the event.
   external JsObject get target;
 
-  ///  The object that originally fired the event. For non-propagated events, this will be the same as the  target.
+  /// The object that originally fired the event. For non-propagated events, this will be the same as the  target.
   external JsObject get sourceTarget;
 
   /// For propagated events, the last object that propagated the event to its event parent.
@@ -193,7 +193,7 @@ class LeafletLocationEvent extends LeafletEvent {
   /// Current velocity in meters per second
   external double get speed;
 
-  ///   The time when the position was acquired.
+  ///  The time when the position was acquired.
   external double get timestamp;
 }
 
@@ -217,7 +217,7 @@ class LeafletLayerEvent extends LeafletEvent {
 @JS()
 @anonymous
 class LeafletLayersControlEvent extends LeafletEvent {
-  ///  The layer that was added or removed.
+  /// The layer that was added or removed.
   external Layer get layer;
 
   /// The name of the layer that was added or removed.
@@ -227,7 +227,7 @@ class LeafletLayersControlEvent extends LeafletEvent {
 @JS()
 @anonymous
 class LeafletTileEvent extends LeafletEvent {
-  ///  The tile element (image). coords Point Point object with the tile's x, y, and z (zoom level) coordinates.
+  /// The tile element (image). coords Point Point object with the tile's x, y, and z (zoom level) coordinates.
   external Element get tile;
 }
 
@@ -250,7 +250,7 @@ class LeafletResizeEvent extends LeafletEvent {
   /// The old size before resize event.
   external Point get oldSize;
 
-  ///  The new size after the resize event.
+  /// The new size after the resize event.
   external Point get newSize;
 }
 
@@ -264,26 +264,36 @@ class LeafletPopupEvent extends LeafletEvent {
 @JS()
 @anonymous
 class LeafletTooltipEvent extends LeafletEvent {
-  ///  The tooltip that was opened or closed.
+  /// The tooltip that was opened or closed.
   external Tooltip get tooltip;
 }
 
 @JS()
 @anonymous
 class LeafletDragEndEvent {
-  ///  The distance in pixels the draggable element was moved by.
+  /// The distance in pixels the draggable element was moved by.
   external double get distance;
 }
 
 @JS()
 @anonymous
 class LeafletZoomAnimEvent {
-  /// The current center of the map
+  /// The current center of the map.
   external LatLng get center;
 
-  ///  The current zoom level of the map
+  /// The current zoom level of the map.
   external double get zoom;
 
-  /// Whether layers should update their contents due to this event
+  /// Whether layers should update their contents due to this event.
   external bool get noUpdate;
+}
+
+@JS()
+@anonymous
+class LeafletMoveEvent extends LeafletEvent {
+  /// The old coordinates of the marker.
+  external LatLng get oldLatLng;
+
+  /// The new coordinates of the marker.
+  external LatLng get latlng;
 }

--- a/lib/src/geojson.dart
+++ b/lib/src/geojson.dart
@@ -1,26 +1,27 @@
 @JS()
 library leaflet.geojson;
 
+import 'package:dartleaf/dartleaf.dart';
 import 'package:js/js.dart';
 
 class Type {
   /// For type "Point", the "coordinates" member is a single position.
-  static const point = "Point";
+  static const point = 'Point';
 
   /// For type "MultiPoint", the "coordinates" member is an array of positions
-  static const multiPoint = "MultiPoint";
+  static const multiPoint = 'MultiPoint';
 
   /// For type "LineString", the "coordinates" member is an array of two or more positions.
-  static const lineString = "LineString";
+  static const lineString = 'LineString';
 
   /// For type "MultiLineString", the "coordinates" member is an array of LineString coordinate arrays.
-  static const multiLineString = "MultiLineString";
+  static const multiLineString = 'MultiLineString';
 
   /// For type "Polygon", the "coordinates" member MUST be an array of linear ring coordinate arrays.
-  static const polygon = "Polygon";
+  static const polygon = 'Polygon';
 
-  ///  For type "MultiPolygon", the "coordinates" member is an array of Polygon coordinate arrays.
-  static const multiPolygon = "MultiPolygon";
+  /// For type "MultiPolygon", the "coordinates" member is an array of Polygon coordinate arrays.
+  static const multiPolygon = 'MultiPolygon';
 }
 
 @JS()
@@ -35,18 +36,118 @@ class Geometry {
   external set coordinates(List value);
 }
 
+@JS('L.geoJSON')
+class GeoJson extends Layer with Evented {
+  external GeoJson([
+    dynamic geojson,
+    GeoJsonOptions options,
+  ]);
+
+  /// Optional object in GeoJSON format to display on the map.
+  external dynamic get geojson;
+  external set geojson(dynamic value);
+
+  /// GeoJson options.
+  external GeoJsonOptions get options;
+  external set options(GeoJsonOptions value);
+
+  /// Methods
+  /// -------
+
+  /// Adds a GeoJSON object to the layer.
+  external GeoJson addData(dynamic data);
+
+  /// Resets the given vector layer's style to the original GeoJSON style,
+  /// useful for resetting style after hover events.
+  /// If [layer] is omitted, the style of all features in the current layer is reset.
+  external GeoJson resetStyle([Layer layer]);
+
+  /// Changes styles of GeoJSON vector layers with the given style function.
+  external GeoJson setStyle(Function style);
+
+  /// Static methods
+  /// --------------
+
+  /// Creates a Layer from a given GeoJSON feature.
+  /// Can use a custom pointToLayer and/or coordsToLatLng functions if provided as options.
+  external static Layer geometryToLayer(dynamic featureData, GeoJson options);
+
+  /// Creates a LatLng object from an array of 2 numbers (longitude, latitude)
+  /// or 3 numbers (longitude, latitude, altitude) used in GeoJSON for points.
+  external static LatLng coordsToLatLng(List coords);
+
+  /// Creates a multidimensional array of LatLngs from a GeoJSON coordinates array.
+  ///
+  /// [levelsDeep] specifies the nesting level
+  /// (0 is for an array of points, 1 for an array of arrays of points, etc., 0 by default).
+  ///
+  /// Can use a custom [coordsToLatLng] function.
+  external static List coordsToLatLngs(List coords,
+      [int levelsDeep, Function coordsToLatLng]);
+
+  /// Reverse of [coordsToLatLng]
+  external static List latLngToCoords(LatLng latlng, num precision);
+
+  /// Reverse of [coordsToLatLngs].
+  ///
+  /// [closed] determines whether the first point should be appended to the end
+  /// of the array to close the feature, only used when levelsDeep is 0.
+  /// False by default.
+  external static List latLngsToCoords(List latlngs,
+      [int levelsDeep, bool closed = false]);
+
+  /// Normalize GeoJSON geometries/features into GeoJSON features.
+  external static dynamic asFeature(dynamic geojson);
+}
+
 @JS()
 @anonymous
-class GeoJson {
-  external factory GeoJson(
-      {String type, Geometry geometry, Map<String, dynamic> properties});
+class GeoJsonOptions extends LayerOptions {
+  external factory GeoJsonOptions({
+    String pane,
+    String attribution,
+    bool markersInheritOptions,
+    Layer Function(dynamic geoJsonPoint, LatLng latlng) pointToLayer,
+    PathOptions Function(dynamic geoJsonFeature) style,
+    Function(dynamic feature, Layer layer) onEachFeature,
+    bool Function(dynamic geoJsonFeature) filter,
+    Function coordsToLatLng,
+  });
 
-  external String get type;
-  external set type(String value);
+  /// Whether default Markers for "Point" type Features inherit from group options.
+  external bool get markersInheritOptions;
+  external set markersInheritOptions(bool value);
 
-  external Geometry get geometry;
-  external set geometry(Geometry value);
+  /// A Function defining how GeoJSON points spawn Leaflet layers.
+  /// It is internally called when data is added, passing the GeoJSON point feature and its LatLng.
+  /// The default is to spawn a default Marker.
+  external Layer Function(dynamic geoJsonPoint, LatLng latlng) get pointToLayer;
+  external set pointToLayer(
+      Layer Function(dynamic geoJsonPoint, LatLng latlng) value);
 
-  external Map<String, dynamic> get properties;
-  external set properties(Map<String, dynamic> value);
+  /// A Function defining the Path options for styling GeoJSON lines and polygons,
+  /// called internally when data is added.
+  /// The default value is to not override any defaults.
+  external PathOptions Function(dynamic geoJsonFeature) get style;
+  external set style(PathOptions Function(dynamic geoJsonFeature) value);
+
+  /// A Function that will be called once for each created Feature, after it has been created and styled.
+  /// Useful for attaching events and popups to features.
+  /// The default is to do nothing with the newly created layers.
+  external Function(dynamic feature, Layer layer) get onEachFeature;
+  external set onEachFeature(Function(dynamic feature, Layer layer) value);
+
+  /// A Function that will be used to decide whether to include a feature or not.
+  /// The default is to include all features.
+  ///
+  /// Note:
+  /// Dynamically changing the filter option will have effect only on newly added data.
+  /// It will not re-evaluate already included features.
+  external bool Function(dynamic geoJsonFeature) get filter;
+  external set filter(bool Function(dynamic geoJsonFeature) value);
+
+  /// A Function that will be used for converting GeoJSON coordinates to LatLngs.
+  /// The default is the coordsToLatLng static method.
+  external Function get coordsToLatLng;
+  external set coordsToLatLng(Function value);
 }

--- a/lib/src/handler.dart
+++ b/lib/src/handler.dart
@@ -3,7 +3,7 @@ library leaflet.handler;
 
 import 'package:js/js.dart';
 
-@JS("Handler")
+@JS('Handler')
 class Handler {
   external Handler enable();
   external Handler disable();

--- a/lib/src/icon.dart
+++ b/lib/src/icon.dart
@@ -5,33 +5,34 @@ import 'dart:html';
 import 'package:js/js.dart';
 import 'point.dart';
 
-@JS("L.icon")
+@JS('L.icon')
 class Icon {
-  external Icon(IconOptions options);
+  external factory Icon(IconOptions options);
 
   /// Called internally when the icon has to be shown.
   /// returns a <img> HTML element styled according to the options
   external Element createIcon([Element oldIcon]);
 
-  ///As createIcon, but for the shadow beneath it.
+  /// As createIcon, but for the shadow beneath it.
   external Element createShadow([Element oldIcon]);
 }
 
 @JS()
 @anonymous
 class IconOptions {
-  external factory IconOptions(
-      {String iconUrl,
-      String iconRetinaUrl,
-      Point iconSize,
-      Point iconAnchor,
-      Point popupAnchor,
-      Point tooltipAnchor,
-      String shadowUrl,
-      String shadowRetinaUrl,
-      Point shadowSize,
-      Point shadowAnchor,
-      String className});
+  external factory IconOptions({
+    String iconUrl,
+    String iconRetinaUrl,
+    Point iconSize,
+    Point iconAnchor,
+    Point popupAnchor,
+    Point tooltipAnchor,
+    String shadowUrl,
+    String shadowRetinaUrl,
+    Point shadowSize,
+    Point shadowAnchor,
+    String className,
+  });
 
   /// (required) The URL to the icon image (absolute or relative to your script path).
   external String get iconUrl;
@@ -45,8 +46,8 @@ class IconOptions {
   external Point get iconSize;
   external set iconSize(Point value);
 
-  /// The coordinates of the "tip" of the icon (relative to its top left
-  /// corner). The icon will be aligned so that this point is at the
+  /// The coordinates of the "tip" of the icon (relative to its top left corner).
+  /// The icon will be aligned so that this point is at the
   /// marker's geographical location. Centered by default if size is
   /// specified, also can be set in CSS with negative margins.
   external Point get iconAnchor;
@@ -78,4 +79,31 @@ class IconOptions {
   /// A custom class name to assign to both icon and shadow images. Empty by default.
   external String get className;
   external set className(String value);
+}
+
+@JS('L.divIcon')
+class DivIcon extends Icon {
+  external factory DivIcon(DivIconOptions options);
+}
+
+@JS()
+@anonymous
+class DivIconOptions extends Icon {
+  external factory DivIconOptions({
+    String html,
+    Point bgPos,
+    Point iconSize,
+    Point iconAnchor,
+    Point popupAnchor,
+    Point tooltipAnchor,
+    String className,
+  });
+
+  /// Custom HTML code to put inside the div element, empty by default.
+  external String get html;
+  external set html(String value);
+
+  /// Optional relative position of the background, in pixels.
+  external Point get bgPos;
+  external set bgPos(Point value);
 }

--- a/lib/src/latlng.dart
+++ b/lib/src/latlng.dart
@@ -4,7 +4,7 @@ library leaflet.latlng;
 import 'package:js/js.dart';
 import 'latlng_bounds.dart';
 
-@JS("L.latLng")
+@JS('L.latLng')
 class LatLng {
   /// Creates an object representing a geographical point with the given latitude and
   /// longitude (and optionally altitude).
@@ -44,6 +44,8 @@ class LatLng {
 @JS()
 @anonymous
 class LatCoordinate {
+  external factory LatCoordinate({double lat, double lng, double alt});
+
   external double get lat;
   external set lat(double value);
 
@@ -52,6 +54,4 @@ class LatCoordinate {
 
   external double get alt;
   external set alt(double value);
-
-  external factory LatCoordinate({double lat, double lng, double alt});
 }

--- a/lib/src/latlng_bounds.dart
+++ b/lib/src/latlng_bounds.dart
@@ -5,7 +5,7 @@ import 'package:js/js.dart';
 import 'latlng.dart';
 import 'bounds.dart';
 
-@JS("L.latLngBounds")
+@JS('L.latLngBounds')
 
 /// Represents a rectangular geographical area on a map.
 class LatLngBounds {
@@ -66,7 +66,7 @@ class LatLngBounds {
 
   /// Returns true if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of
   /// error can be overridden by setting max Margin to a small number.
-  external equals(LatLngBounds otherBounds, [double maxMargin]);
+  external bool equals(LatLngBounds otherBounds, [double maxMargin]);
 
   /// Returns true if the bounds are properly initialized.
   external bool isValid();

--- a/lib/src/layer.dart
+++ b/lib/src/layer.dart
@@ -12,7 +12,7 @@ import 'evented.dart';
 import 'geojson.dart';
 import 'point.dart';
 
-@JS("L.layer")
+@JS('L.layer')
 class Layer {
   /// Adds the layer to the given map or layer group.
   external Layer addTo(LeafletMap map);
@@ -43,7 +43,7 @@ class Layer {
 
   /// Binds a popup to the layer with the passed content and sets up the necessary event listeners.
   /// If a Function is passed it will receive the layer as the first argument and should return a String or HTMLElement
-  external bindPopup(Popup content);
+  external Layer bindPopup(Popup content);
 
   /// Removes the popup previously bound with bindPopup.
   external Layer unbindPopup();
@@ -95,6 +95,11 @@ class Layer {
 @JS()
 @anonymous
 class LayerOptions {
+  external factory LayerOptions({
+    String pane,
+    String attribution,
+  });
+
   /// By default the layer will be added to the map's overlay pane.
   /// Overriding this option will cause the layer to be placed on another pane by default.
   external String get pane;
@@ -106,7 +111,7 @@ class LayerOptions {
   external set attribution(String value);
 }
 
-@JS("L.gridLayer")
+@JS('L.gridLayer')
 class GridLayer extends Layer {
   /// Creates a new instance of GridLayer with the supplied options
   external GridLayer([GridLayerOptions options]);
@@ -139,6 +144,13 @@ class GridLayer extends Layer {
 @JS()
 @anonymous
 class InteractiveLayerOptions extends LayerOptions {
+  external factory InteractiveLayerOptions({
+    String pane,
+    String attribution,
+    bool interactive,
+    bool bubblingMouseEvents,
+  });
+
   /// If false, the layer will not emit mouse events and will act as a part of the underlying map.
   external bool get interactive;
   external set interactive(bool value);
@@ -151,6 +163,25 @@ class InteractiveLayerOptions extends LayerOptions {
 @JS()
 @anonymous
 class GridLayerOptions extends LayerOptions {
+  external factory GridLayerOptions({
+    String pane,
+    String attribution,
+    Point tileSize,
+    double opacity,
+    bool updateWhenIdle,
+    bool updateWhenZooming,
+    double updateInterval,
+    double zIndex,
+    LatLngBounds bounds,
+    double minZoom,
+    double maxZoom,
+    double maxNativeZoom,
+    double minNativeZoom,
+    bool noWrap,
+    String className,
+    double keepBuffer,
+  });
+
   /// Width and height of tiles in the grid. Use a number if width and height are equal, or L.point(width, height) otherwise.
   external Point get tileSize;
   external set tileSize(Point value);
@@ -219,7 +250,7 @@ class GridLayerOptions extends LayerOptions {
   external set keepBuffer(double value);
 }
 
-@JS("L.tileLayer")
+@JS('L.tileLayer')
 class TileLayer extends GridLayer with Evented {
   /// Instantiates a tile layer object given a URL template and optionally an options object.
   external TileLayer(String urlTemplate, [TileLayerOptions options]);
@@ -232,14 +263,31 @@ class TileLayer extends GridLayer with Evented {
 @JS()
 @anonymous
 class TileLayerOptions extends GridLayerOptions {
-  external factory TileLayerOptions(
-      {String subdomains,
-      String errorTileUrl,
-      double zoomOffset,
-      bool tms,
-      bool zoomReverse,
-      bool detectRetina,
-      String crossOrigin});
+  external factory TileLayerOptions({
+    String attribution,
+    Point tileSize,
+    double opacity,
+    bool updateWhenIdle,
+    bool updateWhenZooming,
+    double updateInterval,
+    double zIndex,
+    LatLngBounds bounds,
+    double minZoom,
+    double maxZoom,
+    double maxNativeZoom,
+    double minNativeZoom,
+    bool noWrap,
+    String pane,
+    String className,
+    double keepBuffer,
+    String subdomains,
+    String errorTileUrl,
+    double zoomOffset,
+    bool tms,
+    bool zoomReverse,
+    bool detectRetina,
+    String crossOrigin,
+  });
 
   /// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain
   /// name) or an array of strings.
@@ -280,6 +328,13 @@ class DivOverlay extends Layer {}
 @JS()
 @anonymous
 class DivOverlayOptions extends LayerOptions {
+  external factory DivOverlayOptions({
+    String attribution,
+    Point offset,
+    String className,
+    String pane,
+  });
+
   /// The offset of the popup position. Useful to control the anchor of the popup when opening it on some overlays.
   external Point get offset;
   external set offset(Point value);
@@ -288,12 +343,12 @@ class DivOverlayOptions extends LayerOptions {
   external String get className;
   external set className(String value);
 
-  ///Map pane where the popup will be added.
+  /// Map pane where the popup will be added.
   external String get pane;
   external set pane(String value);
 }
 
-@JS("L.layerGroup")
+@JS('L.layerGroup')
 class LayerGroup extends Layer with Evented {
   external LayerGroup([List layers, LayerOptions options]);
 
@@ -318,9 +373,12 @@ class LayerGroup extends Layer with Evented {
   external LayerGroup invoke(String methodName);
 
   /// Iterates over the layers of the group, optionally specifying context of the iterator function.
-  /// group.eachLayer(function (layer) {
+  ///
+  /// ```dart
+  /// group.eachLayer(allowInterop((layer) {
   ///   layer.bindPopup('Hello');
-  ///});
+  /// }));
+  /// ```
   external LayerGroup eachLayer(Function fn);
 
   /// Returns the layer with the given internal ID.
@@ -334,4 +392,10 @@ class LayerGroup extends Layer with Evented {
 
   /// Returns the internal ID for a layer
   external double getLayerId(List layer);
+}
+
+/// Extended [LayerGroup] that makes it easier to do the same thing to all its member layers
+@JS('L.featureGroup')
+class FeatureGroup extends LayerGroup {
+  external FeatureGroup(List layers);
 }

--- a/lib/src/leaflet_map.dart
+++ b/lib/src/leaflet_map.dart
@@ -18,7 +18,7 @@ import 'tooltip.dart';
 import 'evented.dart';
 import 'handler.dart';
 
-@JS("L.map")
+@JS('L.map')
 class LeafletMap with Evented {
   /// Instantiates a map object given the DOM ID of a <div> element and optionally an object literal with LeafletMap options
   external LeafletMap(String id, [MapOptions options]);
@@ -91,10 +91,10 @@ class LeafletMap with Evented {
 // external LeafletMap setZoomAround(Point offset, double zoom, ZoomOptions);
 
   /// Sets a map view that contains the given geographical bounds with the maximum zoom level possible.
-  external LeafletMap fitBounds(LatLngBounds bounds, [FitBounds options]);
+  external LeafletMap fitBounds(LatLngBounds bounds, [FitBoundOptions options]);
 
   /// Sets a map view that mostly contains the whole world with the maximum zoom level possible.
-  external LeafletMap fitWorld([FitBounds options]);
+  external LeafletMap fitWorld([FitBoundOptions options]);
 
   /// Pans the map to a given center.
   external LeafletMap panTo(LatLng latlng, [PanOptions options]);
@@ -303,45 +303,46 @@ class LeafletMap with Evented {
 @JS()
 @anonymous
 class MapOptions {
-  external factory MapOptions(
-      {bool preferCanvas,
-      bool attributionControl,
-      bool zoomControl,
-      bool closePopupOnClick,
-      double zoomSnap,
-      double zoomDelta,
-      bool trackResize,
-      bool boxZoom,
-      bool doubleClickZoom,
-      bool dragging,
-      CRS crs,
-      LatLng center,
-      double zoom,
-      double minZoom,
-      double maxZoom,
-      List<Layer> layers,
-      LatLngBounds maxBounds,
-      Renderer renderer,
-      bool zoomAnimation,
-      double zoomAnimationThreshold,
-      bool fadeAnimation,
-      bool markerZoomAnimation,
-      double transform3DLimit,
-      bool inertia,
-      double inertiaDeceleration,
-      double inertiaMaxSpeed,
-      double easeLinearity,
-      bool worldCopyJump,
-      double maxBoundsViscosity,
-      bool keyboard,
-      bool keyboardPanDelta,
-      bool scrollWheelZoom,
-      double wheelDebounceTime,
-      double wheelPxPerZoomLevel,
-      bool tap,
-      double tapTolerance,
-      bool touchZoom,
-      bool bounceAtZoomLimits});
+  external factory MapOptions({
+    bool preferCanvas,
+    bool attributionControl,
+    bool zoomControl,
+    bool closePopupOnClick,
+    double zoomSnap,
+    double zoomDelta,
+    bool trackResize,
+    bool boxZoom,
+    bool doubleClickZoom,
+    bool dragging,
+    CRS crs,
+    LatLng center,
+    double zoom,
+    double minZoom,
+    double maxZoom,
+    List layers,
+    LatLngBounds maxBounds,
+    Renderer renderer,
+    bool zoomAnimation,
+    double zoomAnimationThreshold,
+    bool fadeAnimation,
+    bool markerZoomAnimation,
+    double transform3DLimit,
+    bool inertia,
+    double inertiaDeceleration,
+    double inertiaMaxSpeed,
+    double easeLinearity,
+    bool worldCopyJump,
+    double maxBoundsViscosity,
+    bool keyboard,
+    bool keyboardPanDelta,
+    bool scrollWheelZoom,
+    double wheelDebounceTime,
+    double wheelPxPerZoomLevel,
+    bool tap,
+    double tapTolerance,
+    bool touchZoom,
+    bool bounceAtZoomLimits,
+  });
 
   /// Whether Paths should be rendered on a Canvas renderer. By default, all Paths are rendered in a SVG renderer.
   external bool get preferCanvas;

--- a/lib/src/locate_options.dart
+++ b/lib/src/locate_options.dart
@@ -6,13 +6,14 @@ import 'package:js/js.dart';
 @JS()
 @anonymous
 class LocateOptions {
-  external factory LocateOptions(
-      {bool watch,
-      bool setView,
-      double maxZoom,
-      double timeout,
-      double maximumAge,
-      bool enableHighAccuracy});
+  external factory LocateOptions({
+    bool watch,
+    bool setView,
+    double maxZoom,
+    double timeout,
+    double maximumAge,
+    bool enableHighAccuracy,
+  });
 
   /// If true, starts continuous watching of location changes (instead of detecting it once)
   /// using W3C watchPosition method. You can later stop watching using map.stopLocate() method.

--- a/lib/src/marker.dart
+++ b/lib/src/marker.dart
@@ -9,7 +9,7 @@ import 'latlng.dart';
 import 'evented.dart';
 import 'geojson.dart';
 
-@JS("L.marker")
+@JS('L.marker')
 class Marker extends Layer with Evented {
   external Marker(LatLng latlng, [MarkerOptions options]);
 
@@ -39,21 +39,24 @@ class Marker extends Layer with Evented {
 @JS()
 @anonymous
 class MarkerOptions extends InteractiveLayerOptions {
-  external factory MarkerOptions(
-      {Icon icon,
-      bool keyboard,
-      String title,
-      String alt,
-      double zIndexOffset,
-      double opacity,
-      bool riseOnHover,
-      double riseOffset,
-      String pane,
-      bool bubblingMouseEvents,
-      bool draggable,
-      bool autoPan,
-      Point autoPanPadding,
-      double autoPanSpeed});
+  external factory MarkerOptions({
+    String attribution,
+    bool interactive,
+    Icon icon,
+    bool keyboard,
+    String title,
+    String alt,
+    double zIndexOffset,
+    double opacity,
+    bool riseOnHover,
+    double riseOffset,
+    String pane,
+    bool bubblingMouseEvents,
+    bool draggable,
+    bool autoPan,
+    Point autoPanPadding,
+    double autoPanSpeed,
+  });
 
   /// Icon instance to use for rendering the marker. See Icon documentation
   /// for details on how to customize the marker icon. If not specified, a

--- a/lib/src/path.dart
+++ b/lib/src/path.dart
@@ -28,22 +28,26 @@ class Path extends Layer with Evented {
 
 @JS()
 @anonymous
-class PathOptions extends LayerOptions {
-  external factory PathOptions(
-      {bool stroke,
-      String color,
-      double weight,
-      double opacity,
-      String lineCap,
-      String lineJoin,
-      String dashArray,
-      String dashOffset,
-      bool fill,
-      String fillColor,
-      double fillOpacity,
-      String fillRule,
-      Renderer renderer,
-      String className});
+class PathOptions extends InteractiveLayerOptions {
+  external factory PathOptions({
+    String pane,
+    String attribution,
+    bool interactive,
+    bool stroke,
+    String color,
+    double weight,
+    double opacity,
+    String lineCap,
+    String lineJoin,
+    String dashArray,
+    String dashOffset,
+    bool fill,
+    String fillColor,
+    double fillOpacity,
+    String fillRule,
+    Renderer renderer,
+    String className,
+  });
 
   /// Whether to draw stroke along the path. Set it to false to   disable borders on polygons or circles.
   external bool get stroke;
@@ -106,7 +110,7 @@ class PathOptions extends LayerOptions {
   external set className(String value);
 }
 
-@JS("L.polyline")
+@JS('L.polyline')
 class Polyline extends Path {
   /// Instantiates a polyline object given an array of geographical points and optionally an options object.
   /// You can create a Polyline object with multiple separate lines (MultiPolyline) by passing an array of
@@ -144,7 +148,24 @@ class Polyline extends Path {
 @JS()
 @anonymous
 class PolylineOptions extends PathOptions {
-  external factory PolylineOptions();
+  external factory PolylineOptions({
+    bool stroke,
+    String color,
+    double weight,
+    double opacity,
+    String lineCap,
+    String lineJoin,
+    String dashArray,
+    String dashOffset,
+    bool fill,
+    String fillColor,
+    double fillOpacity,
+    String fillRule,
+    Renderer renderer,
+    String className,
+    double smoothFactor,
+    bool noClip,
+  });
 
   ///How much to simplify the polyline on each zoom level. More means better performance and smoother look,
   /// and less means more accurate representation.
@@ -156,17 +177,17 @@ class PolylineOptions extends PathOptions {
   external set noClip(bool value);
 }
 
-@JS("L.polygon")
+@JS('L.polygon')
 class Polygon extends Polyline {
   external factory Polygon(List latlngs, [PolylineOptions options]);
 }
 
-@JS("L.rectangle")
+@JS('L.rectangle')
 class Rectangle extends Polyline {
   external factory Rectangle(LatLngBounds latlngs, [PolylineOptions options]);
 }
 
-@JS("L.circleMarker")
+@JS('L.circleMarker')
 class CircleMarker extends Path {
   /// Instantiates a circle marker object given a geographical point, and an optional options object.
   external factory CircleMarker(LatLng latlng, [CircleOptions options]);
@@ -192,6 +213,23 @@ class CircleMarker extends Path {
 @anonymous
 class CircleOptions extends PathOptions {
   external factory CircleOptions({
+    String pane,
+    String attribution,
+    bool interactive,
+    bool stroke,
+    String color,
+    double weight,
+    double opacity,
+    String lineCap,
+    String lineJoin,
+    String dashArray,
+    String dashOffset,
+    bool fill,
+    String fillColor,
+    double fillOpacity,
+    String fillRule,
+    Renderer renderer,
+    String className,
     double radius,
   });
 
@@ -200,7 +238,7 @@ class CircleOptions extends PathOptions {
   external set radius(double value);
 }
 
-@JS("L.circle")
+@JS('L.circle')
 class Circle extends CircleMarker {
   external factory Circle(LatLng latlng, [CircleOptions options]);
 }

--- a/lib/src/point.dart
+++ b/lib/src/point.dart
@@ -3,7 +3,7 @@ library leaflet.point;
 
 import 'package:js/js.dart';
 
-@JS("L.point")
+@JS('L.point')
 class Point {
   /// Creates a Point object with the given x and y coordinates. If optional round is set to true, rounds the x and y values.
   external Point(double x, double y, [bool round]);

--- a/lib/src/popup.dart
+++ b/lib/src/popup.dart
@@ -9,7 +9,7 @@ import 'latlng.dart';
 import 'leaflet_map.dart';
 import 'evented.dart';
 
-@JS("L.popup")
+@JS('L.popup')
 class Popup extends DivOverlay with Evented {
   external Popup([PopupOptions options, Layer source]);
 
@@ -49,19 +49,23 @@ class Popup extends DivOverlay with Evented {
 @JS()
 @anonymous
 class PopupOptions extends DivOverlayOptions {
-  external factory PopupOptions(
-      {double maxWidth,
-      double minWidth,
-      double maxHeight,
-      double autoPan,
-      Point autoPanPaddingTopLeft,
-      Point autoPanPaddingBottomRight,
-      Point autoPanPadding,
-      bool closeButton,
-      bool autoClose,
-      bool closeOnEscapeKey,
-      bool closeOnClick,
-      String className});
+  external factory PopupOptions({
+    Point offset,
+    String pane,
+    String attribution,
+    double maxWidth,
+    double minWidth,
+    double maxHeight,
+    double autoPan,
+    Point autoPanPaddingTopLeft,
+    Point autoPanPaddingBottomRight,
+    Point autoPanPadding,
+    bool closeButton,
+    bool autoClose,
+    bool closeOnEscapeKey,
+    bool closeOnClick,
+    String className,
+  });
 
   /// Max width of the popup, in pixels.
   external double get maxWidth;

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -4,7 +4,7 @@ library leaflet.renderer;
 import 'package:js/js.dart';
 import 'layer.dart';
 
-@JS("Renderer")
+@JS('Renderer')
 class Renderer extends Layer {
   /// How much to extend the clip area around the map view (relative to its size)
   /// e.g. 0.1 would be 10% of map view in each direction

--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -6,7 +6,7 @@ import 'layer.dart';
 import 'point.dart';
 import 'evented.dart';
 
-@JS("L.tooltip")
+@JS('L.tooltip')
 class Tooltip extends DivOverlay with Evented {
   /// Instantiates a Tooltip object given an optional options object that describes its appearance and location
   /// and an optional source object that is used to tag the tooltip with a reference to the Layer to which it refers.
@@ -16,14 +16,17 @@ class Tooltip extends DivOverlay with Evented {
 @JS()
 @anonymous
 class TooltipOptions extends DivOverlayOptions {
-  external factory TooltipOptions(
-      {String pane,
-      Point offset,
-      String direction,
-      bool permanent,
-      bool sticky,
-      bool interactive,
-      double opacity});
+  external factory TooltipOptions({
+    String attribution,
+    String className,
+    String pane,
+    Point offset,
+    String direction,
+    bool permanent,
+    bool sticky,
+    bool interactive,
+    double opacity,
+  });
 
   /// Map pane where the tooltip will be added.
   external String get pane;


### PR DESCRIPTION
This PR covers:

- (**_breaking change_**) removed `FitBound` class (duplicate of `FitBoundOptions`) 
- (**_breaking change_**) refactored `GeoJson` and defined `GeoJsonOptions`
- added `L.divIcon` definition
- added `L.control.zoom`, `L.control.attribution`, `L.control.scale`, `L.control.layers` definitions
- defined missing factory constructors for anonymous classes with named parameters
- added inherited properties to the anonymous classes factory constructor
- minor formatting and analysis warning fixes
- applied [leaflet 1.6.0 changes](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#160)
